### PR TITLE
More flexibility for hyperparameter search in biopsykit.classification

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -37,5 +37,5 @@ jobs:
     - name: "Check Codecov"
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+    status:
+        patch: off
+        project: off

--- a/examples/SklearnPipelinePermuter_Example.ipynb
+++ b/examples/SklearnPipelinePermuter_Example.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Specify Estimator Combinations and Hyperparameter for Grid Search"
+    "## Specify Estimator Combinations and Parameters for Hyperparameter Search"
    ]
   },
   {
@@ -135,6 +135,12 @@
     "    #    \"n_estimators\": np.arange(20, 110, 10),\n",
     "    #    \"learning_rate\": np.arange(0.6, 1.1, 0.1)\n",
     "    #},\n",
+    "}\n",
+    "\n",
+    "\n",
+    "# use randomized-search for decision tree classifier, use grid-search (the default) for all other estimators\n",
+    "hyper_search_dict = {\n",
+    "    \"DecisionTreeClassifier\": {\"search_method\": \"random\", \"n_iter\": 2}\n",
     "}"
    ]
   },
@@ -151,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipeline_permuter = SklearnPipelinePermuter(model_dict, params_dict)"
+    "pipeline_permuter = SklearnPipelinePermuter(model_dict, params_dict, hyper_search_dict=hyper_search_dict)"
    ]
   },
   {
@@ -241,6 +247,13 @@
    "source": [
     "pipeline_permuter.metric_summary()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/biopsykit/classification/model_selection/__init__.py
+++ b/src/biopsykit/classification/model_selection/__init__.py
@@ -1,5 +1,5 @@
 """Module with functions and classes to help with model selection for classification."""
-from biopsykit.classification.model_selection.nested_cv import nested_cv_grid_search
+from biopsykit.classification.model_selection.nested_cv import nested_cv_param_search
 from biopsykit.classification.model_selection.sklearn_pipeline_permuter import SklearnPipelinePermuter
 
-__all__ = ["nested_cv_grid_search", "SklearnPipelinePermuter"]
+__all__ = ["nested_cv_param_search", "SklearnPipelinePermuter"]

--- a/src/biopsykit/classification/model_selection/nested_cv.py
+++ b/src/biopsykit/classification/model_selection/nested_cv.py
@@ -82,16 +82,16 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
     results_dict = {key: [] for key in cols}
 
     for train, test in tqdm(list(outer_cv.split(X, y, groups)), desc="Outer CV"):
+        if isinstance(pipeline.steps[2][1], sklearn.ensemble.RandomForestClassifier) or isinstance(
+                pipeline.steps[2][1], sklearn.ensemble.GradientBoostingClassifier
+        ):
+            grid = RandomizedSearchCV(
+                pipeline, param_distributions=param_dict, cv=inner_cv, scoring=scoring_dict, n_iter=10, **kwargs
+            )
+        else:
+            grid = GridSearchCV(pipeline, param_grid=param_dict, cv=inner_cv, scoring=scoring_dict, **kwargs)
         if groups is None:
             x_train, x_test, y_train, y_test = split_train_test(X, y, train, test)
-            if isinstance(pipeline.steps[2][1], sklearn.ensemble.RandomForestClassifier) or isinstance(
-                pipeline.steps[2][1], sklearn.ensemble.GradientBoostingClassifier
-            ):
-                grid = RandomizedSearchCV(
-                    pipeline, param_distributions=param_dict, cv=inner_cv, scoring=scoring_dict, n_iter=10, **kwargs
-                )
-            else:
-                grid = GridSearchCV(pipeline, param_grid=param_dict, cv=inner_cv, scoring=scoring_dict, **kwargs)
             grid.fit(x_train, y_train)
         else:
             (  # pylint:disable=unbalanced-tuple-unpacking
@@ -102,7 +102,6 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
                 groups_train,
                 _,
             ) = split_train_test(X, y, train, test, groups)
-            grid = GridSearchCV(pipeline, param_grid=param_dict, cv=inner_cv, scoring=scoring_dict, **kwargs)
             grid.fit(x_train, y_train, groups=groups_train)
 
         results_dict["grid_search"].append(grid)

--- a/src/biopsykit/classification/model_selection/nested_cv.py
+++ b/src/biopsykit/classification/model_selection/nested_cv.py
@@ -75,6 +75,7 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
     scoring = kwargs.pop("scoring")
     scoring_dict.setdefault(scoring, scoring)
     kwargs["refit"] = scoring
+    random_state = kwargs.pop("random_state", 1)
 
     cols = ["grid_search", "cv_results", "best_estimator", "conf_matrix", "predicted_labels", "true_labels"]
     for scorer in scoring_dict:
@@ -83,10 +84,16 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
 
     for train, test in tqdm(list(outer_cv.split(X, y, groups)), desc="Outer CV"):
         if isinstance(pipeline.steps[2][1], sklearn.ensemble.RandomForestClassifier) or isinstance(
-                pipeline.steps[2][1], sklearn.ensemble.GradientBoostingClassifier
+            pipeline.steps[2][1], sklearn.ensemble.GradientBoostingClassifier
         ):
             grid = RandomizedSearchCV(
-                pipeline, param_distributions=param_dict, cv=inner_cv, scoring=scoring_dict, n_iter=10, **kwargs
+                pipeline,
+                param_distributions=param_dict,
+                cv=inner_cv,
+                scoring=scoring_dict,
+                n_iter=10,
+                random_state=random_state,
+                **kwargs,
             )
         else:
             grid = GridSearchCV(pipeline, param_grid=param_dict, cv=inner_cv, scoring=scoring_dict, **kwargs)

--- a/src/biopsykit/classification/model_selection/nested_cv.py
+++ b/src/biopsykit/classification/model_selection/nested_cv.py
@@ -69,7 +69,7 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
         sklearn grid-search
 
     """
-    scoring_dict = {"accuracy": "accuracy", "precision": "precision", "recall": "recall", "f1": "f1"}
+    scoring_dict = {"accuracy": "accuracy"}
     scoring = kwargs.pop("scoring")
     scoring_dict.setdefault(scoring, scoring)
     kwargs["refit"] = scoring

--- a/src/biopsykit/classification/model_selection/nested_cv.py
+++ b/src/biopsykit/classification/model_selection/nested_cv.py
@@ -84,9 +84,12 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
     for train, test in tqdm(list(outer_cv.split(X, y, groups)), desc="Outer CV"):
         if groups is None:
             x_train, x_test, y_train, y_test = split_train_test(X, y, train, test)
-            if isinstance(pipeline.steps[2][1], sklearn.ensemble.RandomForestClassifier):
-                grid = RandomizedSearchCV(pipeline, param_distributions=param_dict, cv=inner_cv,
-                                          scoring=scoring_dict, n_iter=10, **kwargs)
+            if isinstance(pipeline.steps[2][1], sklearn.ensemble.RandomForestClassifier) or isinstance(
+                pipeline.steps[2][1], sklearn.ensemble.GradientBoostingClassifier
+            ):
+                grid = RandomizedSearchCV(
+                    pipeline, param_distributions=param_dict, cv=inner_cv, scoring=scoring_dict, n_iter=10, **kwargs
+                )
             else:
                 grid = GridSearchCV(pipeline, param_grid=param_dict, cv=inner_cv, scoring=scoring_dict, **kwargs)
             grid.fit(x_train, y_train)

--- a/src/biopsykit/classification/model_selection/nested_cv.py
+++ b/src/biopsykit/classification/model_selection/nested_cv.py
@@ -91,7 +91,7 @@ def nested_cv_grid_search(  # pylint:disable=invalid-name
                 param_distributions=param_dict,
                 cv=inner_cv,
                 scoring=scoring_dict,
-                n_iter=10,
+                n_iter=30,
                 random_state=random_state,
                 **kwargs,
             )

--- a/src/biopsykit/classification/model_selection/nested_cv.py
+++ b/src/biopsykit/classification/model_selection/nested_cv.py
@@ -20,7 +20,7 @@ def nested_cv_param_search(  # pylint:disable=invalid-name
     outer_cv: BaseCrossValidator,
     inner_cv: BaseCrossValidator,
     groups: Optional[np.ndarray] = None,
-    optimizer_setup: Optional[Dict[str, Any]] = None,
+    hyper_search_params: Optional[Dict[str, Any]] = None,
     **kwargs,
 ):
     """Perform a cross-validated parameter search with hyperparameter optimization within a outer cross-validation.
@@ -36,41 +36,45 @@ def nested_cv_param_search(  # pylint:disable=invalid-name
         or a list of such dictionaries, in which case the grids spanned by each dictionary in the list are explored.
         This enables searching over any sequence of parameter settings.
     pipeline : :class:`~sklearn.pipeline.Pipeline`
-        Pipeline of sklearn transforms and estimators to perform grid-search on.
+        Pipeline of sklearn transforms and estimators to perform hyperparameter search with.
     outer_cv : `CV splitter <https://scikit-learn.org/stable/glossary.html#term-CV-splitter>`_
         Cross-validation object determining the cross-validation splitting strategy of the outer cross-validation.
     inner_cv : `CV splitter`_
-        Cross-validation object determining the cross-validation splitting strategy of the grid-search.
+        Cross-validation object determining the cross-validation splitting strategy of the hyperparameter search.
     groups : array-like of shape (`n_samples`,)
         Group labels for the samples used while splitting the dataset into train/test set. Only used in conjunction
         with a "Group"``cv`` instance (e.g., :class:`~sklearn.model_selection.GroupKFold`).
         Default: ``None``
-    optimizer_setup : dict, optional
-        Dictionary specifying which optimization type to use for hyperparameter optimization. Can be one of:
+    hyper_search_params : dict, optional
+        Dictionary specifying which hyperparameter search method to use. Can be one of:
 
             * "grid" (:class:`~sklearn.model_selection.GridSearchCV`): To perform a grid-search pass a dict in the form
               of ``{"search_method": "grid"}``.
             * "random" (:class:`~sklearn.model_selection.RandomizedSearchCV`): To perform a randomized-search pass a
               dict in the form of ``{"search_method": "random", "n_iter": xx}``, where ``"n_iter"`` corresponds to the
-              number of parameter settings that are samples.
+              number of parameter settings that are sampled.
         Default: ``None`` to use grid-search
-    kwargs : Additional arguments to be passed to the :class:`~sklearn.model_selection.GridSearchCV` instance.
+    kwargs : Additional arguments to be passed to the hyperparameter search class instance
+    (e.g., :class:`~sklearn.model_selection.GridSearchCV` or :class:`~sklearn.model_selection.RandomizedSearchCV`).
 
 
     Returns
     -------
     dict
-        Dictionary with grid search results. The result dictionary has the following entries:
+        Dictionary with hyperparameter search results. The result dictionary has the following entries:
 
-        - "grid_search": list with :class:`~sklearn.model_selection.GridSearchCV` instances used for grid search for
-          each outer fold (determined by ``outer_cv``).
+        - "param_search": list with hyperparameter search class instances
+          (e.g., :class:`~sklearn.model_selection.GridSearchCV`) used for hyperparameter search for each outer fold
+          (determined by ``outer_cv``).
         - "test_score":  list with test scores of the best estimator on the respective test set for each outer fold.
-        - "cv_results": list of ``cv_results_`` attributes of :class:`~sklearn.model_selection.GridSearchCV`.
+        - "cv_results": list of ``cv_results_`` attributes of hyperparameter search class
+          (e.g., :class:`~sklearn.model_selection.GridSearchCV`).
           Each entry of "cv_results" is a results dictionary of the respective fold with keys as column headers and
           values as columns, that can be imported into a pandas DataFrame.
-        - "best_estimator" list of ``best_estimator_`` attributes of :class:`~sklearn.model_selection.GridSearchCV`.
-          Each entry of "best_estimator" is the estimator that was chosen by the grid-search in the respective fold,
-          i.e. the estimator which gave the highest average score (or smallest loss if specified) on the test data.
+        - "best_estimator" list of ``best_estimator_`` attributes of hyperparameter search class
+          (e.g., :class:`~sklearn.model_selection.GridSearchCV`). Each entry of "best_estimator" is the estimator that
+          was chosen by the hyperparameter in the respective fold, i.e. the estimator which gave the highest
+          average score (or smallest loss if specified) on the test data.
         - "conf_matrix": list of confusion matrices from test scores for each outer fold
 
     See Also
@@ -85,17 +89,25 @@ def nested_cv_param_search(  # pylint:disable=invalid-name
     scoring = kwargs.pop("scoring")
     scoring_dict.setdefault(scoring, scoring)
     kwargs["refit"] = scoring
-    kwargs.setdefault("random_state", 1)
-    if optimizer_setup is None:
-        optimizer_setup = {"search_method": "grid"}
+    if hyper_search_params is None:
+        hyper_search_params = {"search_method": "grid"}
 
-    cols = ["grid_search", "cv_results", "best_estimator", "conf_matrix", "predicted_labels", "true_labels"]
+    cols = [
+        "param_search",
+        "cv_results",
+        "best_estimator",
+        "conf_matrix",
+        "predicted_labels",
+        "true_labels",
+    ]
     for scorer in scoring_dict:
         cols.append("test_{}".format(scorer))
     results_dict = {key: [] for key in cols}
 
     for train, test in tqdm(list(outer_cv.split(X, y, groups)), desc="Outer CV"):
-        cv_obj = _get_cv_object(pipeline, param_dict, inner_cv, scoring_dict, optimizer_setup, **kwargs)
+        cv_obj = _get_param_search_cv_object(
+            pipeline, param_dict, inner_cv, scoring_dict, hyper_search_params, **kwargs
+        )
         if groups is None:
             x_train, x_test, y_train, y_test = split_train_test(X, y, train, test)
             cv_obj.fit(x_train, y_train)
@@ -110,7 +122,7 @@ def nested_cv_param_search(  # pylint:disable=invalid-name
             ) = split_train_test(X, y, train, test, groups)
             cv_obj.fit(x_train, y_train, groups=groups_train)
 
-        results_dict["grid_search"].append(cv_obj)
+        results_dict["param_search"].append(cv_obj)
         for scorer in scoring_dict:
             results_dict["test_{}".format(scorer)].append(
                 get_scorer(scorer)._score_func(y_test, cv_obj.predict(x_test))
@@ -124,25 +136,25 @@ def nested_cv_param_search(  # pylint:disable=invalid-name
     return results_dict
 
 
-def _get_cv_object(
+def _get_param_search_cv_object(
     pipeline: Pipeline,
     param_dict: Dict[str, Any],
     inner_cv: BaseCrossValidator,
     scoring_dict: Dict[str, str],
-    optimizer_setup: Dict[str, Any],
+    hyper_search_config: Dict[str, Any],
     **kwargs,
 ):
     random_state = kwargs.pop("random_state", None)
-    if optimizer_setup["search_method"] == "random":
+    if hyper_search_config["search_method"] == "random":
         return RandomizedSearchCV(
             pipeline,
             param_distributions=param_dict,
             cv=inner_cv,
             scoring=scoring_dict,
-            n_iter=optimizer_setup["n_iter"],
+            n_iter=hyper_search_config["n_iter"],
             random_state=random_state,
             **kwargs,
         )
-    if optimizer_setup["search_method"] == "grid":
+    if hyper_search_config["search_method"] == "grid":
         return GridSearchCV(pipeline, param_grid=param_dict, cv=inner_cv, scoring=scoring_dict, **kwargs)
-    raise ValueError("Unknown search method {}".format(optimizer_setup["search_method"]))
+    raise ValueError("Unknown search method {}".format(hyper_search_config["search_method"]))

--- a/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
+++ b/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
@@ -54,8 +54,8 @@ class SklearnPipelinePermuter:
             of such dictionaries, in which case the grids spanned by each dictionary in the list are explored.
             This enables searching over any sequence of parameter settings.
         hyper_search_dict : dict, optional
-            Nested dictionary specifying the method for hyperparameter search (e.g., whether to use "grid-search"
-            or "randomized-search") for each estimator. By default, "grid-search" is used for each estimator
+            Nested dictionary specifying the method for hyperparameter search (e.g., whether to use "grid" for grid-search
+            or "random" for randomized-search) for each estimator. By default, "grid-search" is used for each estimator
             unless individually specified otherwise.
 
         Examples
@@ -162,6 +162,7 @@ class SklearnPipelinePermuter:
 
         clf_list = model_dict[list(model_dict.keys())[-1]]
         for clf in clf_list:
+            # fill the dict with the default search method (grid-search) for the classifiers that are not specified explicitly
             self.hyper_search_dict.setdefault(clf, {"search_method": "grid"})
 
         model_combinations = list(product(*[[(step, k) for k in list(model_dict[step].keys())] for step in model_dict]))

--- a/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
+++ b/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
@@ -162,7 +162,7 @@ class SklearnPipelinePermuter:
 
         clf_list = model_dict[list(model_dict.keys())[-1]]
         for clf in clf_list:
-            # fill the dict with the default search method (grid-search) for the classifiers that are not 
+            # fill the dict with the default search method (grid-search) for the classifiers that are not
             # specified explicitly
             self.hyper_search_dict.setdefault(clf, {"search_method": "grid"})
 

--- a/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
+++ b/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
@@ -54,9 +54,9 @@ class SklearnPipelinePermuter:
             of such dictionaries, in which case the grids spanned by each dictionary in the list are explored.
             This enables searching over any sequence of parameter settings.
         hyper_search_dict : dict, optional
-            Nested dictionary specifying the method for hyperparameter search (e.g., whether to use "grid" for grid-search
-            or "random" for randomized-search) for each estimator. By default, "grid-search" is used for each estimator
-            unless individually specified otherwise.
+            Nested dictionary specifying the method for hyperparameter search (e.g., whether to use "grid" for
+            grid-search or "random" for randomized-search) for each estimator. By default, "grid-search" is used
+            for each estimator unless individually specified otherwise.
 
         Examples
         --------
@@ -162,7 +162,8 @@ class SklearnPipelinePermuter:
 
         clf_list = model_dict[list(model_dict.keys())[-1]]
         for clf in clf_list:
-            # fill the dict with the default search method (grid-search) for the classifiers that are not specified explicitly
+            # fill the dict with the default search method (grid-search) for the classifiers that are not 
+            # specified explicitly
             self.hyper_search_dict.setdefault(clf, {"search_method": "grid"})
 
         model_combinations = list(product(*[[(step, k) for k in list(model_dict[step].keys())] for step in model_dict]))

--- a/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
+++ b/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
@@ -187,6 +187,7 @@ class SklearnPipelinePermuter:
         outer_cv: BaseCrossValidator,
         inner_cv: BaseCrossValidator,
         scoring: Optional[str] = None,
+        optimizer_setup_list = None,
         **kwargs,
     ):
         """Run fit for all pipeline combinations and sets of parameters.
@@ -225,7 +226,7 @@ class SklearnPipelinePermuter:
         location = cachedir_name
         memory = Memory(location=location, verbose=0)
 
-        for model_combination in tqdm(self.model_combinations):
+        for i, model_combination in tqdm(enumerate(self.model_combinations)):
             if model_combination in self.grid_searches:
                 # continue if we already tried this combination
                 continue
@@ -250,8 +251,13 @@ class SklearnPipelinePermuter:
                 )
             )
 
-            for i, param_dict in enumerate(pipeline_params):
-                print("Parameter grid #{}: {}".format(i, param_dict))
+            if optimizer_setup_list:
+                optimizer_setup = optimizer_setup_list[i]
+            else:
+                optimizer_setup = None
+
+            for j, param_dict in enumerate(pipeline_params):
+                print("Parameter grid #{}: {}".format(j, param_dict))
                 model_cls = [(step, self.models[step][m]) for step, m in model_combination]
                 pipeline = Pipeline(model_cls, memory=memory)
 
@@ -263,6 +269,7 @@ class SklearnPipelinePermuter:
                     outer_cv=outer_cv,
                     inner_cv=inner_cv,
                     scoring=scoring,
+                    optimizer_setup=optimizer_setup,
                     **kwargs,
                 )
 

--- a/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
+++ b/src/biopsykit/classification/model_selection/sklearn_pipeline_permuter.py
@@ -219,9 +219,10 @@ class SklearnPipelinePermuter:
         kwargs.setdefault("n_jobs", -1)
         kwargs.setdefault("verbose", 1)
         kwargs.setdefault("error_score", "raise")
+        cachedir_name = kwargs.pop("cachedir_name", "cachedir")
 
         # Create a temporary folder to store the transformers of the pipeline
-        location = "cachedir"
+        location = cachedir_name
         memory = Memory(location=location, verbose=0)
 
         for model_combination in tqdm(self.model_combinations):


### PR DESCRIPTION
This PR adds more flexibility to the hyperparameter search in the module `biopsykit.classification`. Instead of being forced to use grid-search users can now specify for each pipeline combination individually whether to use grid-search or randomized-search for hyperparameter search.